### PR TITLE
Refresh auto

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,6 +102,9 @@ app.register(localAuth, {
   // refreshCookie: {
   //  ...
   // },
+  // Automatically refreshes access tokens in a x-access-token-header
+  // when an expired access token is used and a refresh token is in cookies.
+  // autoRefresh: false,
   signUp(user) {
     // Enter some logic to process signups and return a UserType
     return { id: "some-id", provider: "email" };
@@ -122,7 +125,7 @@ app.register(localAuth, {
 
 ### Defaults
 
-- Access Tokens expire in 24 hours.
+- Access Tokens expire in 24 hours and do not auto refresh.
 - Refresh Tokens expire in 30 days.
 - Refresh Tokens stored in a HttpOnly SameSite=Lax Cookie
 - Jti is a uuid.
@@ -131,9 +134,9 @@ app.register(localAuth, {
 ### Protecting routes
 
 ```ts
-fastify.addHook("onRequest", async (req, _reply) => {
-  await req.accessVerify();
-});
+import fastify from "fastify";
+
+fastify.addHook("onRequest", fastify.authorize);  
 ```
 
 ### Customizing the UserType
@@ -183,6 +186,6 @@ docker run -p 5000:5000 -d  --name jumpstart-app fastify-jumpstart
 ## Todo:
 
 - [x] Auth
-- [ ] Refresh access token automatically if it fails and refresh token is there
+- [x] Refresh access token automatically if it fails and refresh token is there
 - [ ] Type enforce defining jti for custom jwt settings
 - [ ] API Versioning

--- a/src/app.ts
+++ b/src/app.ts
@@ -1,7 +1,6 @@
 import fastify, { FastifyServerOptions } from "fastify";
 import swagger from "@fastify/swagger";
 import { TypeBoxTypeProvider } from "@fastify/type-provider-typebox";
-import { apiRouter } from "./routes/api";
 import { healthRoute } from "./routes/health";
 import sensible from "@fastify/sensible";
 
@@ -24,7 +23,6 @@ export function build(opts?: FastifyServerOptions) {
     },
   });
 
-  app.register(apiRouter, { prefix: "/api" });
   app.register(healthRoute);
   app.register(sensible);
 

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -4,6 +4,10 @@ declare module "fastify" {
   interface FastifyInstance {
     prom: typeof prom;
     promRegister: Registry;
+    authorize: (
+      req: FastifyRequest,
+      reply: FastifyReply
+    ) => void | Promise<void>;
   }
 
   interface FastifyRequest {

--- a/src/plugins/localAuth.test.ts
+++ b/src/plugins/localAuth.test.ts
@@ -1,6 +1,7 @@
 import t from "tap";
 import { build } from "../app";
 import localAuth from "./localAuth";
+import { FastifyInstance } from "fastify";
 
 const setupApp = (overrides?: Partial<Parameters<typeof localAuth>[1]>) => {
   const app = build();
@@ -19,6 +20,17 @@ const setupApp = (overrides?: Partial<Parameters<typeof localAuth>[1]>) => {
     },
     ...overrides,
   });
+
+  app.register(
+    (instance, opts, done) => {
+      instance.addHook("onRequest", instance.authorize);
+      instance.get("/", (req, reply) => {
+        reply.send("Success");
+      });
+      done();
+    },
+    { prefix: "/protected-test" }
+  );
 
   return app;
 };
@@ -125,19 +137,7 @@ t.test("local auth plugin", (t) => {
     t.test("refresh success", async (t) => {
       const app = setupApp();
 
-      const tokenRes = await app.inject({
-        method: "POST",
-        url: "/auth/login",
-        payload: {
-          email: "email@email.com",
-          password: "password@password.com",
-        },
-      });
-
-      const cookie = tokenRes.cookies.pop() as {
-        name: "fastify-refresh";
-        value: string;
-      };
+      const { cookie } = await loginAndGetTokenAndCookie(app);
 
       const res = await app.inject({
         method: "POST",
@@ -148,7 +148,7 @@ t.test("local auth plugin", (t) => {
       t.ok(res.statusCode === 200);
     });
 
-    t.test("refresh fail", async (t) => {
+    t.test("refresh fail missing cookie", async (t) => {
       const app = setupApp({
         refresh(_jti: string): boolean | Promise<boolean> {
           return false;
@@ -163,8 +163,131 @@ t.test("local auth plugin", (t) => {
       t.equal(res.statusCode, 401);
     });
 
+    t.test("refresh auto success", async (t) => {
+      const app = setupApp({
+        autoRefresh: true,
+        accessJwt: {
+          secret: process.env.JWT_SECRET!,
+          sign: {
+            algorithm: "HS256",
+            expiresIn: 1,
+          },
+          namespace: "access",
+          jwtVerify: "accessVerify",
+          jwtSign: "accessSign",
+        },
+      });
+
+      const { cookie, accessToken } = await loginAndGetTokenAndCookie(app);
+
+      await delay(1100);
+
+      const finalRes = await app.inject({
+        method: "GET",
+        url: "/protected-test",
+        headers: {
+          authorization: `Bearer ${accessToken}`,
+        },
+        cookies: { "fastify-refresh": cookie.value },
+      });
+
+      t.equal(finalRes.statusCode, 200);
+      t.ok(finalRes.headers["x-access-token"]);
+      t.equal(finalRes.body, "Success");
+      t.notSame(finalRes.cookies.pop(), cookie);
+    });
+
+    t.test("refresh auto fail: No refresh token", async (t) => {
+      const app = setupApp({
+        autoRefresh: true,
+        accessJwt: {
+          secret: process.env.JWT_SECRET!,
+          sign: {
+            algorithm: "HS256",
+            expiresIn: 1,
+          },
+          namespace: "access",
+          jwtVerify: "accessVerify",
+          jwtSign: "accessSign",
+        },
+      });
+
+      const { accessToken } = await loginAndGetTokenAndCookie(app);
+
+      await delay(1100);
+
+      const finalRes = await app.inject({
+        method: "GET",
+        url: "/protected-test",
+        headers: {
+          authorization: `Bearer ${accessToken}`,
+        },
+      });
+
+      t.equal(finalRes.statusCode, 401);
+    });
+
+    t.end();
+  });
+
+  t.test("authorize", (t) => {
+    t.test("fails on missing header", async (t) => {
+      const app = setupApp();
+
+      const res = await app.inject({
+        method: "GET",
+        url: "/protected-test",
+      });
+
+      t.equal(res.statusCode, 401);
+      t.ok(res.body.includes("Must include a Bearer authorization."));
+    });
+
+    t.test("Fails on not a bearer header", async (t) => {
+      const app = setupApp();
+      const { accessToken } = await loginAndGetTokenAndCookie(app);
+
+      const res = await app.inject({
+        method: "GET",
+        url: "/protected-test",
+        headers: {
+          authorization: `Basic ${accessToken}`,
+        },
+      });
+
+      t.equal(res.statusCode, 401);
+      t.ok(res.body.includes("Must include a Bearer authorization."));
+    });
+
     t.end();
   });
 
   t.end();
 });
+
+async function loginAndGetTokenAndCookie(app: FastifyInstance) {
+  const tokenRes = await app.inject({
+    method: "POST",
+    url: "/auth/login",
+    payload: {
+      email: "email@email.com",
+      password: "password@password.com",
+    },
+  });
+
+  const cookie = tokenRes.cookies.pop() as {
+    name: "fastify-refresh";
+    value: string;
+  };
+
+  const { accessToken } = tokenRes.json<{ accessToken: string }>();
+
+  return {
+    accessToken,
+    cookie,
+  };
+}
+
+function delay(time: number) {
+  return new Promise((resolve) => setTimeout(resolve, time));
+}

--- a/src/plugins/localAuth.ts
+++ b/src/plugins/localAuth.ts
@@ -216,7 +216,7 @@ const localAuthPlugin: FastifyPluginCallback<LocalAuthPluginOptions> = (
       await req.accessVerify();
     } catch (e) {
       if (opts.autoRefresh) {
-        const { message } = await refresh(req, reply);
+        const { message } = await refresh(req, reply, true);
         if (message) {
           return reply.unauthorized(message);
         }
@@ -228,7 +228,8 @@ const localAuthPlugin: FastifyPluginCallback<LocalAuthPluginOptions> = (
 
   async function refresh(
     req: FastifyRequest,
-    reply: FastifyReply
+    reply: FastifyReply,
+    includeHeader = false
   ): Promise<RefreshReply> {
     const { payload: decoded } = await req.refreshVerify<{
       payload: UserType & { exp: number; jti: string };
@@ -268,7 +269,7 @@ const localAuthPlugin: FastifyPluginCallback<LocalAuthPluginOptions> = (
 
     reply.setCookie(REFRESH_COOKIE_NAME, refreshToken, cookieOpts);
     // Pass auto-refreshed token to header
-    reply.header("X-Access-Token", token);
+    if (includeHeader) reply.header("X-Access-Token", token);
 
     return {
       decoded,

--- a/src/plugins/localAuth.ts
+++ b/src/plugins/localAuth.ts
@@ -1,12 +1,12 @@
 import { randomUUID } from "crypto";
-import { FastifyPluginCallback } from "fastify";
+import { FastifyPluginCallback, FastifyReply, FastifyRequest } from "fastify";
 import fp from "fastify-plugin";
 import jwt, { UserType } from "@fastify/jwt";
 import cookie, { CookieSerializeOptions } from "@fastify/cookie";
 import { TypeBoxTypeProvider } from "@fastify/type-provider-typebox";
 import { PostUserSchema } from "../schema/user";
 import { AuthSuccessResSchema } from "../schema/auth";
-import type { LocalAuthPluginOptions } from "../types/types";
+import type { LocalAuthPluginOptions, RefreshReply } from "../types/types";
 
 const localAuthPlugin: FastifyPluginCallback<LocalAuthPluginOptions> = (
   instance,
@@ -81,6 +81,8 @@ const localAuthPlugin: FastifyPluginCallback<LocalAuthPluginOptions> = (
       },
     }
   );
+
+  fastify.decorate("authorize", authorize);
 
   fastify.post(
     `${path}/signup`,
@@ -189,45 +191,91 @@ const localAuthPlugin: FastifyPluginCallback<LocalAuthPluginOptions> = (
       },
     },
     async (req, reply) => {
-      const { payload: decoded } = await req.refreshVerify<{
-        payload: UserType & { exp: number; jti: string };
-      }>({
-        complete: true,
-        onlyCookie: true,
-      });
+      const { decoded, accessToken, message } = await refresh(req, reply);
 
-      // Pass in the jti to a refresh token check
-      if (!(await opts.refresh(decoded.jti))) {
-        return reply.unauthorized("Invalid refresh token");
+      if (message || !accessToken) {
+        return reply.unauthorized(message);
       }
 
-      const token = await reply.accessSign(
-        { id: decoded.id, provider: decoded.provider },
-        {
-          sign: {
-            sub: decoded.id,
-          },
-        }
-      );
-
-      const refreshToken = await reply.refreshSign(
-        { id: decoded.id, provider: decoded.provider },
-        {
-          sign: {
-            sub: decoded.id,
-          },
-        }
-      );
-
-      reply.setCookie(REFRESH_COOKIE_NAME, refreshToken, cookieOpts);
-
       return {
-        accessToken: token,
+        accessToken,
         userId: decoded.id,
         provider: decoded.provider,
       };
     }
   );
+
+  async function authorize(req: FastifyRequest, reply: FastifyReply) {
+    if (
+      !req.headers.authorization ||
+      req.headers.authorization.split(" ")[0] !== "Bearer"
+    ) {
+      return reply.unauthorized("Must include a Bearer authorization.");
+    }
+    try {
+      await req.accessVerify();
+    } catch (e) {
+      if (opts.autoRefresh) {
+        const { message } = await refresh(req, reply);
+        if (message) {
+          return reply.unauthorized(message);
+        }
+      } else {
+        return reply.unauthorized("Invalid access token");
+      }
+    }
+  }
+
+  async function refresh(
+    req: FastifyRequest,
+    reply: FastifyReply
+  ): Promise<RefreshReply> {
+    const { payload: decoded } = await req.refreshVerify<{
+      payload: UserType & { exp: number; jti: string };
+    }>({
+      complete: true,
+      onlyCookie: true,
+    });
+
+    // Check refresh hook
+    if (!(await opts.refresh(decoded.jti))) {
+      return {
+        decoded,
+        accessToken: null,
+        message: "Unauthorized request",
+      };
+    }
+
+    // Sign new access token
+    const token = await reply.accessSign(
+      { id: decoded.id, provider: decoded.provider },
+      {
+        sign: {
+          sub: decoded.id,
+        },
+      }
+    );
+
+    // Sign new refresh token
+    const refreshToken = await reply.refreshSign(
+      { id: decoded.id, provider: decoded.provider },
+      {
+        sign: {
+          sub: decoded.id,
+        },
+      }
+    );
+
+    reply.setCookie(REFRESH_COOKIE_NAME, refreshToken, cookieOpts);
+    // Pass auto-refreshed token to header
+    reply.header("X-Access-Token", token);
+
+    return {
+      decoded,
+      accessToken: token,
+      message: undefined,
+    };
+  }
 
   done();
 };

--- a/src/routes/api/index.test.ts
+++ b/src/routes/api/index.test.ts
@@ -1,9 +1,11 @@
 import t from "tap";
 import { build } from "../../app";
+import { apiRouter } from "./index";
 
 t.test("api root", (t) => {
   t.test("Outputs version", async (t) => {
     const app = build();
+    app.register(apiRouter, { prefix: "/api" });
 
     const res = await app.inject({
       method: "GET",

--- a/src/routes/api/protected/protected.ts
+++ b/src/routes/api/protected/protected.ts
@@ -9,9 +9,7 @@ export const protectedRouter: FastifyPluginCallback = (
   const fastify = instance.withTypeProvider<TypeBoxTypeProvider>();
 
   // Verifies an access token on each request after adding hook
-  fastify.addHook("onRequest", async (req, _reply) => {
-    await req.accessVerify();
-  });
+  fastify.addHook("onRequest", fastify.authorize);
 
   fastify.get("/", async (req, reply) => {
     reply.send(`hello ${req.user.id}`);

--- a/src/server.ts
+++ b/src/server.ts
@@ -4,6 +4,7 @@ import { build } from "./app";
 import { config } from "./config/config";
 import prom from "./plugins/prom";
 import localAuth from "./plugins/localAuth";
+import { apiRouter } from "./routes/api";
 
 const app = build({
   logger: config[process.env.NODE_ENV ?? "production"].logger,
@@ -57,6 +58,8 @@ if (process.env.NODE_ENV !== "production") {
     return app.swagger();
   });
 }
+
+app.register(apiRouter, { prefix: "/api" });
 
 const parsedPort = parseInt(process.env.PORT ?? "5000");
 const PORT = Number.isNaN(parsedPort) ? 5000 : parsedPort;

--- a/src/types/types.ts
+++ b/src/types/types.ts
@@ -11,7 +11,7 @@ export interface LocalAuthPluginOptions {
   accessJwt?: FastifyJWTOptions;
   refreshJwt?: FastifyJWTOptions;
   path?: string;
-
+  autoRefresh?: boolean;
   refreshCookie?: CookieSerializeOptions;
 
   signUp(user: PostUser): UserType | Promise<UserType>;
@@ -22,3 +22,15 @@ export interface LocalAuthPluginOptions {
 
   refresh(jti: string): boolean | Promise<boolean>;
 }
+
+export type RefreshReply =
+  | {
+      message: undefined;
+      accessToken: string;
+      decoded: UserType & { exp: number; jti: string };
+    }
+  | {
+      message: string;
+      accessToken: null;
+      decoded: UserType & { exp: number; jti: string };
+    };


### PR DESCRIPTION
- Add autoRefresh option in localAuth plugin
- authorize decorator added for encapsulating authorization logic.
- With auto refresh, if an authorization request has an invalid access token but a valid refresh token in the cookies, it will attach a new acccess token in the x-access-token header.